### PR TITLE
feat(migrations): added name field and made title field nullable

### DIFF
--- a/db/migrations/20190909131232_add_name_to_movies.js
+++ b/db/migrations/20190909131232_add_name_to_movies.js
@@ -1,0 +1,15 @@
+'use strict';
+
+exports.up = async (Knex) => {
+  await Knex.schema.table('movies', (table) => {
+    table.text('name');
+  });
+  await Knex.raw('ALTER TABLE movies ALTER COLUMN title DROP NOT NULL');
+};
+
+exports.down = async (Knex) => {
+  await Knex.schema.table('movies', (table) => {
+    table.dropColumn('name');
+  });
+  await Knex.raw('ALTER TABLE movies ALTER COLUMN title SET NOT NULL');
+};


### PR DESCRIPTION
**Changed a column name in the sfmovies db**
**Why:** Need to change a field name from `title` to `name` 
**What:** This PR is just a migration for adding the new field `name` and making the existing field `title` nullable. 