### PR TITLE
feat(schema-changes): updated app code to stop saving title. wrote a migration to add not null constraint to name and drop title

### DIFF
--- a/db/migrations/20190911160416_drop_title_from_movies.js
+++ b/db/migrations/20190911160416_drop_title_from_movies.js
@@ -1,0 +1,22 @@
+'use strict';
+
+exports.up = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.dropColumn('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies ADD CONSTRAINT movies_name_not_null CHECK (name IS NOT NULL) NOT VALID')
+    .then(() => {
+      return Knex.raw('ALTER TABLE movies VALIDATE CONSTRAINT movies_name_not_null');
+    });
+  });
+};
+
+exports.down = (Knex) => {
+  return Knex.schema.table('movies', (table) => {
+    table.text('title');
+  })
+  .then(() => {
+    return Knex.raw('ALTER TABLE movies DROP CONSTRAINT movies_name_not_null');
+  });
+};

--- a/lib/models/movie.js
+++ b/lib/models/movie.js
@@ -7,7 +7,7 @@ module.exports = Bookshelf.Model.extend({
   serialize: function () {
     return {
       id: this.get('id'),
-      title: this.get('title'),
+      name: this.get('name'),
       release_year: this.get('release_year'),
       object: 'movie'
     };

--- a/lib/plugins/features/movies/controller.js
+++ b/lib/plugins/features/movies/controller.js
@@ -4,7 +4,7 @@ const Movie = require('../../../models/movie');
 
 exports.create = async (payload) => {
 
-  payload.name = payload.title;
+  // payload.name = payload.title;
 
   const movie = await new Movie().save(payload);
 

--- a/lib/validators/movie.js
+++ b/lib/validators/movie.js
@@ -3,6 +3,6 @@
 const Joi = require('joi');
 
 module.exports = Joi.object().keys({
-  title: Joi.string().min(1).max(255).required(),
+  name: Joi.string().min(1).max(255).required(),
   release_year: Joi.number().integer().min(1878).max(9999).optional()
 });

--- a/test/models/movie.test.js
+++ b/test/models/movie.test.js
@@ -11,7 +11,7 @@ describe('movie model', () => {
 
       expect(movie).to.have.all.keys([
         'id',
-        'title',
+        'name',
         'release_year',
         'object'
       ]);

--- a/test/plugins/features/movies/controller.test.js
+++ b/test/plugins/features/movies/controller.test.js
@@ -7,10 +7,10 @@ describe('movie controller', () => {
   describe('create', () => {
 
     it('creates a movie', async () => {
-      const payload = { title: 'WALL-E' };
+      const payload = { name: 'WALL-E' };
       const movie = await Controller.create(payload);
 
-      expect(movie.get('title')).to.eql(payload.title);
+      expect(movie.get('name')).to.eql(payload.name);
     });
 
   });

--- a/test/plugins/features/movies/index.test.js
+++ b/test/plugins/features/movies/index.test.js
@@ -10,7 +10,7 @@ describe('movies integration', () => {
       const response = await Movies.inject({
         url: '/movies',
         method: 'POST',
-        payload: { title: 'Volver' }
+        payload: { name: 'Volver' }
       });
 
       expect(response.statusCode).to.eql(200);

--- a/test/validators/movie.test.js
+++ b/test/validators/movie.test.js
@@ -5,21 +5,21 @@ const MovieValidator = require('../../lib/validators/movie');
 
 describe('movie validator', () => {
 
-  describe('title', () => {
+  describe('name', () => {
 
     it('is required', () => {
       const payload = {};
       const result = Joi.validate(payload, MovieValidator);
 
-      expect(result.error.details[0].path[0]).to.eql('title');
+      expect(result.error.details[0].path[0]).to.eql('name');
       expect(result.error.details[0].type).to.eql('any.required');
     });
 
     it('is less than 255 characters', () => {
-      const payload = { title: 'a'.repeat(260) };
+      const payload = { name: 'a'.repeat(260) };
       const result = Joi.validate(payload, MovieValidator);
 
-      expect(result.error.details[0].path[0]).to.eql('title');
+      expect(result.error.details[0].path[0]).to.eql('name');
       expect(result.error.details[0].type).to.eql('string.max');
     });
 
@@ -29,7 +29,7 @@ describe('movie validator', () => {
 
     it('is after 1878', () => {
       const payload = {
-        title: 'foo',
+        name: 'foo',
         release_year: 1800
       };
       const result = Joi.validate(payload, MovieValidator);
@@ -40,7 +40,7 @@ describe('movie validator', () => {
 
     it('is limited to 4 digits', () => {
       const payload = {
-        title: 'foo',
+        name: 'foo',
         release_year: 12345
       };
       const result = Joi.validate(payload, MovieValidator);


### PR DESCRIPTION
**Step 3 of Column Change in sfmovies db** 

**What:** This is the last step in the migration for changing sfmovies field name from `title` to `name`. 
- Updated the application code to stop saving to the `title` column. 
- Wrote a migration to add a not-null constraint to `name` and drop `title`. 

**Why:** At this point, the schema change is complete. `title` is officially no longer a field and consumers know to use the new `name` field. 